### PR TITLE
feat: material 3 expressive

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.NextSongTileService"
@@ -81,6 +84,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.PreviousSongTileService"
@@ -92,6 +98,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.MediaVolumeTileService"
@@ -103,6 +112,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
 
         <service
@@ -115,6 +127,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.AdaptiveBrightnessTileService"
@@ -225,6 +240,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.NewTimerTileService"
@@ -236,6 +254,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.TakePhotoTileService"
@@ -247,6 +268,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.RecordVideoTileService"
@@ -258,6 +282,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenCalculatorTileService"
@@ -269,6 +296,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenVolumePanelTileService"
@@ -280,6 +310,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.BrightnessTileService"
@@ -324,6 +357,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenDataUsageTileService"
@@ -335,6 +371,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenAboutPhoneTileService"
@@ -346,6 +385,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenConnectedDevicesTileService"
@@ -357,6 +399,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenNotificationLogTileService"
@@ -368,6 +413,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenSettingsSearchTileService"
@@ -379,6 +427,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.NewCalendarEventTileService"
@@ -390,6 +441,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.MakeCallTileService"
@@ -401,6 +455,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.CounterTileService"
@@ -412,6 +469,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.ScreenTimeoutTileService"
@@ -478,6 +538,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenDeveloperOptionsTileService"
@@ -489,6 +552,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenLocaleTileService"
@@ -500,6 +566,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenAppOneTileService"
@@ -592,6 +661,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenHomeTileService"
@@ -603,6 +675,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenPrivacyTileService"
@@ -614,6 +689,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenUserDictionaryTileService"
@@ -625,6 +703,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".accessibility_tiles.PowerDialogTileService"
@@ -636,6 +717,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".accessibility_tiles.ScreenshotTileService"
@@ -647,6 +731,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".accessibility_tiles.LockScreenTileService"
@@ -658,6 +745,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".accessibility_tiles.ToggleSplitScreenTileService"
@@ -669,6 +759,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.HeadsUpTileService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -511,6 +511,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenAppTwoTileService"
@@ -522,6 +525,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenAppThreeTileService"
@@ -533,6 +539,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenAppFourTileService"
@@ -544,6 +553,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".intent_tiles.OpenAppFiveTileService"
@@ -555,6 +567,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
         </service>
         <service
             android:name=".tiles.SilenceLoudSwitchTileService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="true"
@@ -46,6 +47,14 @@
         <activity
             android:name="com.mikepenz.aboutlibraries.ui.LibsActivity"
             android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar" />
+
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".utils.CustomAccessibilityService"

--- a/app/src/main/java/com/flxholle/quicktiles/BootReceiver.java
+++ b/app/src/main/java/com/flxholle/quicktiles/BootReceiver.java
@@ -1,0 +1,36 @@
+package com.flxholle.quicktiles;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.service.quicksettings.TileService;
+import android.util.ArrayMap;
+
+import androidx.preference.PreferenceManager;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (Objects.equals(intent.getAction(), Intent.ACTION_BOOT_COMPLETED)) {
+            // Need update tile after boot
+            ArrayMap<String, Class<?>> preferencesServices = SettingsActivity.getPreferenceService();
+            Map<String, ?> preferences = PreferenceManager.getDefaultSharedPreferences(context).getAll();
+            PackageManager pm = context.getPackageManager();
+            for (Map.Entry<String, Class<?>> entry : preferencesServices.entrySet()) {
+                Object switchPreference = preferences.get(entry.getKey());
+                if (switchPreference != null && switchPreference.equals(Boolean.TRUE)) {
+                    final ComponentName serviceClass = new ComponentName(context, entry.getValue());
+                    pm.setComponentEnabledSetting(serviceClass,
+                            PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
+                    TileService.requestListeningState(context, serviceClass);
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/flxholle/quicktiles/SettingsActivity.java
+++ b/app/src/main/java/com/flxholle/quicktiles/SettingsActivity.java
@@ -1,9 +1,12 @@
 package com.flxholle.quicktiles;
 
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.ArrayMap;
 import android.util.Pair;
+import android.view.View;
+import android.view.Window;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -213,9 +216,19 @@ public class SettingsActivity extends AppCompatActivity implements SearchPrefere
         super.onCreate(savedInstanceState);
         setContentView(R.layout.settings_activity);
 
-        getSupportActionBar().setDisplayShowHomeEnabled(true);
-        getSupportActionBar().setLogo(R.mipmap.ic_launcher);
-        getSupportActionBar().setDisplayUseLogoEnabled(true);
+        Window window = getWindow();
+        window.setStatusBarColor(Color.TRANSPARENT);
+        window.setNavigationBarColor(Color.TRANSPARENT);
+        window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.setStatusBarContrastEnforced(false);
+            window.setNavigationBarContrastEnforced(false);
+        }
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+            getSupportActionBar().setLogo(R.mipmap.ic_launcher);
+            getSupportActionBar().setDisplayUseLogoEnabled(true);
+        }
 
         prefsFragment = new com.flxholle.quicktiles.SettingsFragment();
         getSupportFragmentManager()

--- a/app/src/main/java/com/flxholle/quicktiles/SettingsFragment.java
+++ b/app/src/main/java/com/flxholle/quicktiles/SettingsFragment.java
@@ -27,6 +27,7 @@ import androidx.preference.SwitchPreferenceCompat;
 
 import com.bytehamster.lib.preferencesearch.SearchConfiguration;
 import com.bytehamster.lib.preferencesearch.SearchPreference;
+import com.flxholle.quicktiles.tiles.CounterTileService;
 import com.flxholle.quicktiles.utils.GrantPermissionDialogs;
 import com.flxholle.quicktiles.utils.SelectApp;
 import com.flxholle.quicktiles.utils.SharedPreferencesUtil;
@@ -90,7 +91,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         Preference resetCounter = findPreference("reset_counter");
         resetCounter.setOnPreferenceClickListener((preference -> {
             SharedPreferencesUtil.resetCounter(requireContext());
-//            TileService.requestListeningState(requireContext(), new ComponentName(requireContext(), CounterTileService.class));
+            TileService.requestListeningState(requireContext(), new ComponentName(requireContext(), CounterTileService.class));
             return true;
         }));
     }
@@ -111,6 +112,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             SwitchPreferenceCompat switchPreference = findPreference(entry.getKey());
             if (switchPreference != null) {
                 final Class<?> serviceClass = entry.getValue();
+
+                if (switchPreference.isChecked()) {
+                    setComponentState(true, serviceClass);
+                    TileService.requestListeningState(requireContext(), new ComponentName(requireContext(), serviceClass));
+                }
 
                 if (higherMinApiServices.containsKey(serviceClass)) {
                     Pair<Boolean, Integer> apiValue = higherMinApiServices.get(serviceClass);

--- a/app/src/main/java/com/flxholle/quicktiles/SettingsFragment.java
+++ b/app/src/main/java/com/flxholle/quicktiles/SettingsFragment.java
@@ -8,6 +8,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.service.quicksettings.TileService;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.util.ArrayMap;
@@ -172,7 +173,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     String labelKey = key + "_label";
                     SelectApp.insertCustomAppName(requireContext(), labelKey, preselection, () -> {
                         setComponentState(Boolean.TRUE, serviceClass);
-//                    TileService.requestListeningState(requireContext(), new ComponentName(requireContext(), serviceClass));
+                    TileService.requestListeningState(requireContext(), new ComponentName(requireContext(), serviceClass));
                         ((SwitchPreferenceCompat) preference).setChecked(true);
                         preference.setTitle(SharedPreferencesUtil.getCustomPackage(requireContext(), labelKey));
                     }).show();

--- a/app/src/main/java/com/flxholle/quicktiles/abstract_tiles/BaseTileService.java
+++ b/app/src/main/java/com/flxholle/quicktiles/abstract_tiles/BaseTileService.java
@@ -1,5 +1,6 @@
 package com.flxholle.quicktiles.abstract_tiles;
 
+import android.content.ComponentName;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 
@@ -11,18 +12,19 @@ public abstract class BaseTileService extends TileService {
     // Called when the user adds your tile.
     @Override
     public void onTileAdded() {
+        super.onTileAdded();
+        TileService.requestListeningState(this, new ComponentName(this, this.getClass()));
         Tile tile = getQsTile();
         tile.setState(Tile.STATE_INACTIVE);
         tile.updateTile();
-        super.onTileAdded();
     }
 
     // Called when your app can update your tile.
     @Override
     public void onStartListening() {
+        super.onStartListening();
         Tile tile = getQsTile();
         tile.setState(Tile.STATE_INACTIVE);
         tile.updateTile();
-        super.onStartListening();
     }
 }

--- a/app/src/main/java/com/flxholle/quicktiles/abstract_tiles/OpenCustomAppTileService.java
+++ b/app/src/main/java/com/flxholle/quicktiles/abstract_tiles/OpenCustomAppTileService.java
@@ -11,6 +11,7 @@ public abstract class OpenCustomAppTileService extends IntentTileService {
 
     @Override
     public void onTileAdded() {
+        super.onTileAdded();
         updateState();
     }
 

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -5,6 +5,7 @@
 
     <FrameLayout
         android:id="@+id/settings"
+        android:fitsSystemWindows="true"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 </LinearLayout>


### PR DESCRIPTION
- support fitsSystemWindows for android 36 forced edge-to-edge
- fix non-ACTIVE_TILE slow performance on Material 3 expressive, something delay ~5 seconds when click tiles